### PR TITLE
Fix clang-tidy error warnings

### DIFF
--- a/Core/src/music/Music.cpp
+++ b/Core/src/music/Music.cpp
@@ -29,7 +29,7 @@ void Music::_initSync()
     std::unordered_map<int, int> channelMinNote;
     std::unordered_map<int, int> channelMaxNote;
     std::unordered_set<int> channels;
-    auto& events = _player->popSyncEvents();
+    auto events = _player->popSyncEvents();
     for (auto& se : events) {
         int channel = se.channel;
         int note = se.note;

--- a/Core/src/music/Music.h
+++ b/Core/src/music/Music.h
@@ -32,7 +32,7 @@ inline void Music::setTime(timer::duration_t<T> time)
     sU32 ms = static_cast<sU32>(timer::duration_cast<timer::ms_t>(time).count());
     this->_player->Stop();
     dsClose();
-    auto& events = _player->popSyncEvents();
+    auto events = _player->popSyncEvents();
     this->_player->Play(ms);
     while (this->_player->IsPlaying())
         this->_player->Tick();

--- a/Core/src/music/SyncChannel.cpp
+++ b/Core/src/music/SyncChannel.cpp
@@ -6,16 +6,16 @@
 namespace ojgl {
 
 SyncChannel::SyncChannel()
-    : _minNote(-1)
+    : numNotes(-1)
     , channel(-1)
-    , numNotes(-1)
+    , _minNote(-1)
 {
 }
 
 SyncChannel::SyncChannel(int numNotes, int minNote, int channel)
-    : _minNote(minNote)
+    : numNotes(numNotes)
     , channel(channel)
-    , numNotes(numNotes)
+    , _minNote(minNote)
 {
     _lastTimePerNote.resize(numNotes);
     _timesPerNote.resize(numNotes);

--- a/Core/src/music/V2MPlayer.h
+++ b/Core/src/music/V2MPlayer.h
@@ -46,7 +46,7 @@ class V2MPlayer {
 public:
     std::vector<ojgl::SyncEvent> popSyncEvents();
 
-    void V2MPlayer::Tick();
+    void Tick();
     // init
     // call this instead of a constructor
     void Init(sU32 a_tickspersec = 1000)

--- a/Core/src/render/Buffer.cpp
+++ b/Core/src/render/Buffer.cpp
@@ -7,10 +7,10 @@
 namespace ojgl {
 
 Buffer::Buffer(unsigned width, unsigned height, const std::string& name, const std::string& vertex, const std::string& fragment, std::initializer_list<std::shared_ptr<Buffer>> buffers)
-    : _width(width)
-    , _height(height)
-    , _inputs(buffers)
+    : _inputs(buffers)
     , _name(name)
+    , _width(width)
+    , _height(height)
 {
     loadShader(vertex, fragment);
 }

--- a/Core/src/render/Window.cpp
+++ b/Core/src/render/Window.cpp
@@ -9,7 +9,7 @@ Window::Window(unsigned width, unsigned height, bool fullScreen)
     : _width(width)
     , _height(height)
 {
-    _hWnd = CreateOpenGLWindow("minimal", 0, 0, width, height, PFD_TYPE_RGBA, 0, fullScreen);
+    _hWnd = CreateOpenGLWindow("minimal", 0, 0, PFD_TYPE_RGBA, 0, fullScreen);
     if (_hWnd == NULL)
         exit(1);
 
@@ -20,7 +20,7 @@ Window::Window(unsigned width, unsigned height, bool fullScreen)
 
     Window* pThis = this;
     SetLastError(0);
-    if (!SetWindowLongPtr(_hWnd, GWL_USERDATA, reinterpret_cast<LONG_PTR>(pThis))) {
+    if (!SetWindowLongPtr(_hWnd, GWLP_USERDATA, reinterpret_cast<LONG_PTR>(pThis))) {
         if (GetLastError() != 0)
             throw std::runtime_error("SetWindowLongPtr failed in Window");
     }
@@ -66,7 +66,7 @@ HWND Window::CreateFullscreenWindow(HWND hwnd, HINSTANCE hInstance)
         hwnd, NULL, hInstance, 0);
 }
 
-HWND Window::CreateOpenGLWindow(char* title, int x, int y, int width, int height, BYTE type, DWORD flags, bool fullScreen)
+HWND Window::CreateOpenGLWindow(const char* title, int x, int y, BYTE type, DWORD flags, bool fullScreen)
 {
     int pf;
     HDC hDC;
@@ -98,7 +98,7 @@ HWND Window::CreateOpenGLWindow(char* title, int x, int y, int width, int height
     }
 
     hWnd = CreateWindow(L"OpenGL", L"Hej", WS_OVERLAPPEDWINDOW | WS_CLIPSIBLINGS | WS_CLIPCHILDREN,
-        x, y, width, height, NULL, NULL, hInstance, NULL);
+        x, y, this->_width, this->_height, NULL, NULL, hInstance, NULL);
     if (fullScreen) {
         hWnd = CreateFullscreenWindow(hWnd, hInstance);
     }
@@ -144,7 +144,7 @@ HWND Window::CreateOpenGLWindow(char* title, int x, int y, int width, int height
 
 LONG WINAPI Window::WindowProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
 {
-    Window* pThis = reinterpret_cast<Window*>(GetWindowLongPtr(hWnd, GWL_USERDATA));
+    Window* pThis = reinterpret_cast<Window*>(GetWindowLongPtr(hWnd, GWLP_USERDATA));
 
     static PAINTSTRUCT ps;
 

--- a/Core/src/render/Window.h
+++ b/Core/src/render/Window.h
@@ -21,9 +21,9 @@ public:
     static constexpr int KEY_F1 = 112;
 
 private:
-    HWND CreateOpenGLWindow(char* title, int x, int y, int width, int height, BYTE type, DWORD flags, bool fullScreen);
+    HWND CreateOpenGLWindow(const char* title, int x, int y, BYTE type, DWORD flags, bool fullScreen);
     HWND CreateFullscreenWindow(HWND, HINSTANCE);
-    static LONG WINAPI Window::WindowProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam);
+    static LONG WINAPI WindowProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam);
 
     HDC _hDC; // device context
     HGLRC _hRC; // opengl context


### PR DESCRIPTION
Clang-tidy complained about these warnings (and a lot more which can be fixed later)