### PR TITLE
Buffer cleanup

### DIFF
--- a/ojgl/examples/Main.cpp
+++ b/ojgl/examples/Main.cpp
@@ -20,28 +20,28 @@ void buildSceneGraph(GLState& glState, int x, int y)
         //auto fxaa = Buffer::construct(BufferFormat::Quad, x, y, "fxaa", "shaders/fxaa.vs", "shaders/fxaa.fs", edison);
         //auto post = Buffer::construct(BufferFormat::Quad, x, y, "post", "shaders/post.vs", "shaders/post.fs", fxaa);
 
-        auto mesh = Buffer::construct(BufferFormat::Meshes, x, y, "mesh", "shaders/mesh.vs", "shaders/mesh.fs");
+        auto mesh = Buffer::construct(x, y, "mesh", "shaders/mesh.vs", "shaders/mesh.fs", {}, BufferFormat::Meshes);
 
         glState.addScene("meshScene", mesh, Duration::seconds(2));
     }
     {
-        auto noise = Buffer::construct(BufferFormat::Quad, x, y, "intro", "shaders/demo.vs", "shaders/mountainNoise.fs");
-        auto mountain = Buffer::construct(BufferFormat::Quad, x, y, "fxaa", "shaders/demo.vs", "shaders/mountain.fs", noise);
-        auto fxaa = Buffer::construct(BufferFormat::Quad, x, y, "fxaa", "shaders/fxaa.vs", "shaders/fxaa.fs", mountain);
-        auto post = Buffer::construct(BufferFormat::Quad, x, y, "post", "shaders/demo.vs", "shaders/mountainPost.fs", fxaa);
+        auto noise = Buffer::construct(x, y, "intro", "shaders/demo.vs", "shaders/mountainNoise.fs");
+        auto mountain = Buffer::construct(x, y, "fxaa", "shaders/demo.vs", "shaders/mountain.fs", { noise });
+        auto fxaa = Buffer::construct(x, y, "fxaa", "shaders/fxaa.vs", "shaders/fxaa.fs", { mountain });
+        auto post = Buffer::construct(x, y, "post", "shaders/demo.vs", "shaders/mountainPost.fs", { fxaa });
         glState.addScene("introScene", post, Duration::seconds(77));
     }
 
     {
-        auto edison = Buffer::construct(BufferFormat::Quad, x, y, "intro", "shaders/edison.vs", "shaders/lavaScene2.fs");
-        auto fxaa = Buffer::construct(BufferFormat::Quad, x, y, "fxaa", "shaders/fxaa.vs", "shaders/fxaa.fs", edison);
-        auto post = Buffer::construct(BufferFormat::Quad, x, y, "post", "shaders/post.vs", "shaders/post.fs", fxaa);
+        auto edison = Buffer::construct(x, y, "intro", "shaders/edison.vs", "shaders/lavaScene2.fs");
+        auto fxaa = Buffer::construct(x, y, "fxaa", "shaders/fxaa.vs", "shaders/fxaa.fs", { edison });
+        auto post = Buffer::construct(x, y, "post", "shaders/post.vs", "shaders/post.fs", { fxaa });
         glState.addScene("introScene", post, Duration::seconds(40));
     }
     {
-        auto edison = Buffer::construct(BufferFormat::Quad, x, y, "intro", "shaders/edison.vs", "shaders/outro.fs");
-        auto fxaa = Buffer::construct(BufferFormat::Quad, x, y, "fxaa", "shaders/fxaa.vs", "shaders/fxaa.fs", edison);
-        auto post = Buffer::construct(BufferFormat::Quad, x, y, "post", "shaders/post.vs", "shaders/post.fs", fxaa);
+        auto edison = Buffer::construct(x, y, "intro", "shaders/edison.vs", "shaders/outro.fs");
+        auto fxaa = Buffer::construct(x, y, "fxaa", "shaders/fxaa.vs", "shaders/fxaa.fs", { edison });
+        auto post = Buffer::construct(x, y, "post", "shaders/post.vs", "shaders/post.fs", { fxaa });
         glState.addScene("introScene", post, Duration::seconds(40));
     }
 }

--- a/ojgl/examples/Main.cpp
+++ b/ojgl/examples/Main.cpp
@@ -22,7 +22,7 @@ void buildSceneGraph(GLState& glState, int x, int y)
 
         auto mesh = Buffer::construct(BufferFormat::Meshes, x, y, "mesh", "shaders/mesh.vs", "shaders/mesh.fs");
 
-        glState.addScene("meshScene", mesh, Duration::seconds(22));
+        glState.addScene("meshScene", mesh, Duration::seconds(2));
     }
     {
         auto noise = Buffer::construct(BufferFormat::Quad, x, y, "intro", "shaders/demo.vs", "shaders/mountainNoise.fs");

--- a/ojgl/src/render/Buffer.cpp
+++ b/ojgl/src/render/Buffer.cpp
@@ -5,6 +5,20 @@
 
 using namespace ojgl;
 
+Buffer::Buffer(unsigned width, unsigned height, const ojstd::string& name, const ojstd::string& vertexPath, const ojstd::string& fragmentPath, const ojstd::vector<BufferPtr>& inputs, BufferFormat format)
+    : _format(format)
+    , _inputs(inputs)
+    , _name(name)
+    , _width(width)
+    , _height(height)
+    , _vertexPath(vertexPath)
+    , _fragmentPath(fragmentPath)
+{
+    loadShader();
+    if (_format == BufferFormat::Quad)
+        _meshes.push_back({ Mesh::constructQuad(), Matrix::identity() });
+}
+
 Buffer::~Buffer()
 {
     if (_fboID != 0) {
@@ -172,4 +186,9 @@ void Buffer::clearMeshes()
 {
     if (_format == BufferFormat::Meshes)
         _meshes.clear();
+}
+
+ojstd::shared_ptr<Buffer> Buffer::construct(unsigned width, unsigned height, const ojstd::string& name, const ojstd::string& vertexPath, const ojstd::string& fragmentPath, const ojstd::vector<BufferPtr>& inputs, BufferFormat format)
+{
+    return ojstd::shared_ptr<Buffer>(new Buffer(width, height, name, vertexPath, fragmentPath, inputs, format));
 }

--- a/ojgl/src/render/Buffer.cpp
+++ b/ojgl/src/render/Buffer.cpp
@@ -3,7 +3,7 @@
 #include "utility/ShaderReader.h"
 #include "winapi/gl_loader.h"
 
-namespace ojgl {
+using namespace ojgl;
 
 Buffer::~Buffer()
 {
@@ -20,11 +20,6 @@ Buffer::~Buffer()
 ojstd::string Buffer::name() const
 {
     return _name;
-}
-
-unsigned Buffer::fboTextureID()
-{
-    return _fboTextureID;
 }
 
 void Buffer::render()
@@ -51,7 +46,7 @@ void Buffer::render()
 
     for (int i = 0; i < _inputs.size(); i++) {
         glActiveTexture(GL_TEXTURE0 + i);
-        glBindTexture(GL_TEXTURE_2D, _inputs[i]->fboTextureID());
+        glBindTexture(GL_TEXTURE_2D, _inputs[i]->_fboID);
     }
 
     index = 0;
@@ -161,9 +156,20 @@ void Buffer::loadShader()
     glDeleteShader(fragID);
 }
 
-GLuint Buffer::getProgramID() const
+Buffer& Buffer::operator<<(const Uniform1t& b)
 {
-    return this->_programID;
+    _textures[b.location()] = ojstd::make_shared<Uniform1t>(b);
+    return *this;
 }
 
-} //namespace ojgl
+void Buffer::insertMesh(const ojstd::shared_ptr<Mesh>& mesh, const Matrix& modelMatrix)
+{
+    _ASSERTE(_format == BufferFormat::Meshes);
+    _meshes.push_back({ mesh, modelMatrix });
+}
+
+void Buffer::clearMeshes()
+{
+    if (_format == BufferFormat::Meshes)
+        _meshes.clear();
+}

--- a/ojgl/src/render/Buffer.h
+++ b/ojgl/src/render/Buffer.h
@@ -23,6 +23,7 @@ public:
     void render();
     void insertMesh(const ojstd::shared_ptr<Mesh>& mesh, const Matrix& modelMatrix);
     void clearMeshes();
+
     auto begin() { return _inputs.begin(); }
     auto begin() const { return _inputs.cbegin(); }
     auto end() { return _inputs.end(); }
@@ -37,43 +38,26 @@ public:
         return *this;
     }
 
-    template <typename... Args>
-    static BufferPtr construct(Args&&... args)
-    {
-        return ojstd::shared_ptr<Buffer>(new Buffer(std::forward<Args>(args)...));
-    }
+    static BufferPtr construct(unsigned width, unsigned height, const ojstd::string& name, const ojstd::string& vertexPath, const ojstd::string& fragmentPath, const ojstd::vector<BufferPtr>& inputs = {}, BufferFormat format = BufferFormat::Quad);
 
 private:
+    Buffer(unsigned width, unsigned height, const ojstd::string& name, const ojstd::string& vertexPath, const ojstd::string& fragmentPath, const ojstd::vector<BufferPtr>& inputs, BufferFormat format);
     void loadShader();
 
-    template <typename... Args>
-    Buffer(BufferFormat format, unsigned width, unsigned height, const ojstd::string& name, const ojstd::string& vertexPath, const ojstd::string& fragmentPath, Args&&... buffers)
-        : _format(format)
-        , _inputs({ std::forward<Args>(buffers)... })
-        , _name(name)
-        , _width(width)
-        , _height(height)
-        , _vertexPath(vertexPath)
-        , _fragmentPath(fragmentPath)
-    {
-        loadShader();
-        if (_format == BufferFormat::Quad)
-            _meshes.push_back({ Mesh::constructQuad(), Matrix::identity() });
-    }
-
 private:
-    ojstd::vector<BufferPtr> _inputs;
+    const ojstd::vector<BufferPtr> _inputs;
     const ojstd::string _name;
+    const ojstd::string _vertexPath;
+    const ojstd::string _fragmentPath;
+    const BufferFormat _format;
+    const unsigned _width;
+    const unsigned _height;
+
     unsigned _programID = 0;
     unsigned _fboID = 0;
     unsigned _fboTextureID = 0;
-    const unsigned _width;
-    const unsigned _height;
     ojstd::unordered_map<ojstd::string, ojstd::shared_ptr<UniformBase>> _uniforms;
     ojstd::unordered_map<ojstd::string, ojstd::shared_ptr<Uniform1t>> _textures;
-    ojstd::string _vertexPath;
-    ojstd::string _fragmentPath;
-    BufferFormat _format;
     ojstd::vector<ojstd::Pair<ojstd::shared_ptr<Mesh>, Matrix>> _meshes;
 };
 


### PR DESCRIPTION
Slight cleanup to the Buffer class.
* Make BufferFormat::Quad a default parameter. 
*  Explicitly write out all arguments, instead of `static BufferPtr construct(Args&&... args)`. To make it a bit more clear. 
* Removed some unused functions.