### PR TITLE
Add support for feedback inputs.

### DIFF
--- a/ojgl/src/render/Buffer.h
+++ b/ojgl/src/render/Buffer.h
@@ -28,14 +28,12 @@ public:
     Buffer& setInputs(T... inputs)
     {
         _inputs = ojstd::vector<BufferPtr>({ inputs... });
-        _numInputs = Buffer::getNumberOfInputs(_inputs);
         return *this;
     }
     template <typename... T>
     Buffer& setFeedbackInputs(T... feedbackInputs)
     {
-        _inputs = ojstd::vector<BufferPtr>({ feedbackInputs... });
-        _numFeedbackInputs = Buffer::getNumberOfInputs(_feedbackInputs);
+        _feedbackInputs = ojstd::vector<BufferPtr>({ feedbackInputs... });
         return *this;
     }
     ojstd::string name() const;
@@ -84,13 +82,13 @@ private:
     void loadShader();
     int numOutTextures();
     static int getNumberOfInputs(const ojstd::vector<BufferPtr>& inputs);
+    const FBO& pushNextFBO();
     const FBO& currentFBO() const;
+    const FBO& previousFBO() const;
 
 private:
     ojstd::vector<BufferPtr> _inputs;
     ojstd::vector<BufferPtr> _feedbackInputs;
-    int _numInputs = 0;
-    int _numFeedbackInputs = 0;
     ojstd::string _name = "default";
     const ojstd::string _vertexPath;
     const ojstd::string _fragmentPath;

--- a/ojgl/src/render/Buffer.h
+++ b/ojgl/src/render/Buffer.h
@@ -6,6 +6,22 @@
 
 namespace ojgl {
 
+class FBO {
+public:
+    FBO(const Vector2i size, int numOutBuffers, bool includeDepthBuffer, bool isOutputBuffer = false);
+    ~FBO();
+    FBO(const FBO& other) = delete;
+
+    auto fboID() const { return _fboID; }
+    auto depthID() const { return _depthID; }
+    auto fboTextureIDs() const { return _fboTextureIDs; }
+
+private:
+    unsigned int _fboID = 0;
+    unsigned int _depthID = 0;
+    ojstd::vector<unsigned int> _fboTextureIDs;
+};
+
 enum class BufferFormat {
     Quad,
     Meshes
@@ -33,7 +49,7 @@ public:
     }
 
     ojstd::string name() const;
-    void generateFBO();
+    void generateFBO(bool isOutputBuffer);
     void render(const Vector2i& viewportOffset);
     void insertMesh(const ojstd::shared_ptr<Mesh>& mesh, const Matrix& modelMatrix);
     void clearMeshes();
@@ -61,6 +77,7 @@ private:
     void loadShader();
     int numOutTextures();
     static int getNumberOfInputs(const ojstd::vector<BufferPtr>& inputs);
+    FBO currentFBO() const;
 
 private:
     ojstd::vector<BufferPtr> _inputs;
@@ -77,9 +94,9 @@ private:
     bool _depthTestEnabled = false;
 
     unsigned _programID = 0;
-    unsigned _fboID = 0;
-    unsigned _depthID = 0;
-    ojstd::vector<unsigned> _fboTextureIDs;
+    ojstd::vector<FBO> _fbos;
+    int _currentFBOIndex = 0;
+
     ojstd::unordered_map<ojstd::string, ojstd::shared_ptr<UniformBase>> _uniforms;
     ojstd::unordered_map<ojstd::string, ojstd::shared_ptr<Uniform1t>> _textures;
     ojstd::vector<ojstd::Pair<ojstd::shared_ptr<Mesh>, Matrix>> _meshes;

--- a/ojgl/src/render/Buffer.h
+++ b/ojgl/src/render/Buffer.h
@@ -31,7 +31,13 @@ public:
         _numInputs = Buffer::getNumberOfInputs(_inputs);
         return *this;
     }
-
+    template <typename... T>
+    Buffer& setFeedbackInputs(T... feedbackInputs)
+    {
+        _inputs = ojstd::vector<BufferPtr>({ feedbackInputs... });
+        _numFeedbackInputs = Buffer::getNumberOfInputs(_feedbackInputs);
+        return *this;
+    }
     ojstd::string name() const;
     void generateFBO(bool isOutputBuffer);
     void render(const Vector2i& viewportOffset);
@@ -82,7 +88,9 @@ private:
 
 private:
     ojstd::vector<BufferPtr> _inputs;
+    ojstd::vector<BufferPtr> _feedbackInputs;
     int _numInputs = 0;
+    int _numFeedbackInputs = 0;
     ojstd::string _name = "default";
     const ojstd::string _vertexPath;
     const ojstd::string _fragmentPath;

--- a/ojgl/src/render/Buffer.h
+++ b/ojgl/src/render/Buffer.h
@@ -6,22 +6,6 @@
 
 namespace ojgl {
 
-class FBO {
-public:
-    FBO(const Vector2i size, int numOutBuffers, bool includeDepthBuffer, bool isOutputBuffer = false);
-    ~FBO();
-    FBO(const FBO& other) = delete;
-
-    auto fboID() const { return _fboID; }
-    auto depthID() const { return _depthID; }
-    auto fboTextureIDs() const { return _fboTextureIDs; }
-
-private:
-    unsigned int _fboID = 0;
-    unsigned int _depthID = 0;
-    ojstd::vector<unsigned int> _fboTextureIDs;
-};
-
 enum class BufferFormat {
     Quad,
     Meshes
@@ -73,11 +57,28 @@ public:
     static BufferPtr construct(unsigned width, unsigned height, const ojstd::string& vertexPath, const ojstd::string& fragmentPath);
 
 private:
+    class FBO {
+    public:
+        FBO(const Vector2i& size, int numOutBuffers, bool includeDepthBuffer, bool isOutputBuffer);
+        ~FBO();
+        FBO(const FBO& other) = delete;
+
+        auto fboID() const { return _fboID; }
+        auto depthID() const { return _depthID; }
+        auto fboTextureIDs() const { return _fboTextureIDs; }
+
+    private:
+        unsigned int _fboID = 0;
+        unsigned int _depthID = 0;
+        ojstd::vector<unsigned int> _fboTextureIDs;
+    };
+
+private:
     Buffer(unsigned width, unsigned height, const ojstd::string& vertexPath, const ojstd::string& fragmentPath);
     void loadShader();
     int numOutTextures();
     static int getNumberOfInputs(const ojstd::vector<BufferPtr>& inputs);
-    FBO currentFBO() const;
+    const FBO& currentFBO() const;
 
 private:
     ojstd::vector<BufferPtr> _inputs;

--- a/ojgl/src/render/Scene.cpp
+++ b/ojgl/src/render/Scene.cpp
@@ -11,10 +11,9 @@ Scene::Scene(const ojstd::string& name, const ojstd::shared_ptr<Buffer>& buffer,
 
 {
     for (auto& b : this->buffers()) {
-        if (b != _mainBuffer) {
-            b->generateFBO();
-        }
+        b->generateFBO(b == _mainBuffer);
     }
+    //@todo verify that no buffer contains the main buffer as feedback input.
 }
 
 Scene::Scene(const ojstd::shared_ptr<Buffer>& buffer, Duration duration)

--- a/ojgl/src/utility/OJstd.cpp
+++ b/ojgl/src/utility/OJstd.cpp
@@ -103,11 +103,11 @@ string& string::operator=(const string& other)
     return *this;
 }
 
-string string::operator+(const string& other)
+string operator+(const string& first, const string& second)
 {
-    char* str = (char*)malloc(sizeof(char) * (len + other.len + 1));
-    strcpy(str, this->content);
-    strcpy(str + len, other.content);
+    char* str = (char*)malloc(sizeof(char) * (first.len + second.len + 1));
+    strcpy(str, first.content);
+    strcpy(str + first.len, second.content);
     return string(std::move(str));
 }
 

--- a/ojgl/src/utility/OJstd.h
+++ b/ojgl/src/utility/OJstd.h
@@ -366,7 +366,8 @@ public:
     ~string();
     bool operator==(const string& other) const;
     string& operator=(const string& other);
-    string operator+(const string& other);
+    friend string operator+(const string& first, const string& second);
+
     char operator[](size_t index) const;
     const char* c_str() const;
     int length() const;


### PR DESCRIPTION
* Add support for feedback inputs (textures of buffers that was rendered the previous frame. Can be itself as well.)
* Each buffer now uses two FBO's where each is rendered every other frame. Add new `FBO` helper class to make it easier to implement.
* Clean up a bit how texture uniforms were set.

Currently the main buffer can't be used as a feedback input. Might fix this in an upcoming PR!