### PR TITLE
Edison 2021 opengl error handling

### DIFF
--- a/ojgl/src/winapi/gl_loader.cpp
+++ b/ojgl/src/winapi/gl_loader.cpp
@@ -105,7 +105,7 @@ int load_gl_functions()
         gl_function_pointers[i] = ptr;
         if (ptr == NULL) {
 #ifdef _DEBUG
-            // Do not assert on mising AMD specifc functions
+            // Do not assert on mising AMD specific functions
             if (name != "glDebugMessageCallbackAMD" && name != "glDebugMessageEnableAMD" && name != "glDebugMessageInsertAMD" && name != "glGetDebugMessageLogAMD") {
                 _ASSERT_EXPR(false, "Failed to load GL func");
             }

--- a/ojgl/src/winapi/gl_loader.cpp
+++ b/ojgl/src/winapi/gl_loader.cpp
@@ -1,5 +1,6 @@
 #include "gl_loader.h"
 #include "Windows.h"
+#include <crtdbg.h>
 
 void* GetAnyGLFuncAddress(const char* name)
 {
@@ -75,12 +76,13 @@ const char* gl_function_names[] = {
     "glDetachShader",
     "glValidateProgram",
     "glUniform1fv",
-    "glUniform2f"
+    "glUniform2f",
+    "glGetProgramInfoLog"
 };
 
 void* gl_function_pointers[sizeof(gl_function_names) / sizeof(const char*)];
 
-#ifdef DEBUG
+#ifdef _DEBUG
 const char* gl_debug_function_names[] = {
     "glGetTextureParameteriv",
     "glDetachShader",
@@ -102,20 +104,23 @@ int load_gl_functions()
         void* ptr = GetAnyGLFuncAddress(name);
         gl_function_pointers[i] = ptr;
         if (ptr == NULL) {
-#ifdef DEBUG
-            trace("Failed to load GL func '%s'", name);
+#ifdef _DEBUG
+            // Do not assert on mising AMD specifc functions
+            if (name != "glDebugMessageCallbackAMD" && name != "glDebugMessageEnableAMD" && name != "glDebugMessageInsertAMD" && name != "glGetDebugMessageLogAMD") {
+                _ASSERT_EXPR(false, "Failed to load GL func");
+            }
 #endif
             failed++;
         }
     }
 
-#ifdef DEBUG
+#ifdef _DEBUG
     for (int i = 0; i < sizeof(gl_debug_function_names) / sizeof(const char*); i++) {
         const char* name = gl_debug_function_names[i];
         void* ptr = GetAnyGLFuncAddress(name);
         gl_debug_function_pointers[i] = ptr;
         if (ptr == NULL) {
-            trace("Failed to load debug GL func '%s'", name);
+            _ASSERT_EXPR(false, "Failed to load debug GL func");
             failed++;
         }
     }

--- a/ojgl/src/winapi/gl_loader.h
+++ b/ojgl/src/winapi/gl_loader.h
@@ -75,6 +75,7 @@ int load_gl_functions();
 #define glValidateProgram ((PFNGLVALIDATEPROGRAMPROC)gl_function_pointers[60])
 #define glUniform1fv ((PFNGLUNIFORM1FVPROC)gl_function_pointers[61])
 #define glUniform2f ((PFNGLUNIFORM2FPROC)gl_function_pointers[62])
+#define glGetProgramInfoLog ((PFNGLGETPROGRAMINFOLOGPROC)gl_function_pointers[63])
 
 #ifdef DEBUG
 extern void* gl_debug_function_pointers[];


### PR DESCRIPTION
- Small helper macros to make the gl code a bit easier to read.

- Call glGetProgramInfoLog instead of glGetShaderInfoLog for program errors

- Check log for glLinkProgram (in addition to glValidateProgram)

- Use `_DEBUG` in gl_loader